### PR TITLE
fix generic_iob direction detection

### DIFF
--- a/gowin_pack.py
+++ b/gowin_pack.py
@@ -52,9 +52,9 @@ def place(db, tilemap, bels):
         elif typ == "GENERIC_IOB":
             assert sum(attr.values()) <= 1, "Complex IOB unsuported"
             iob = tiledata.bels[f'IOB{num}']
-            if attr["INPUT_USED"]:
+            if int(attr["INPUT_USED"], 2):
                 bits = iob.modes['IBUF'] | iob.flags.get('IBUFC', set())
-            elif attr["OUTPUT_USED"]:
+            elif int(attr["OUTPUT_USED"], 2):
                 bits = iob.modes['OBUF'] | iob.flags.get('OBUFC', set())
             else:
                 raise ValueError("IOB has no in or output")


### PR DESCRIPTION
for GENERIC_IOB type, attr is a dict where keys are "INPUT_USED" and "OUTPUT_USED" and values are number of input/output in string (binary representation).
Since values are string, tests:
```
if attr["INPUT_USED"]:
[...]
elif attr["OUTPUT_USED"]:
```
are based on empty/None instead of 0 or > 0.
So, first test is always true and output iob are generate as input too.

fix issue [#9](https://github.com/pepijndevos/apicula/issues/9)
PR [#8](https://github.com/pepijndevos/apicula/pull/8) must be applied too.